### PR TITLE
Updates

### DIFF
--- a/graphital.conf
+++ b/graphital.conf
@@ -1,5 +1,5 @@
 # Your graphite host
-$HOST = 'graphite.vvmedia.com'
+$HOST = '127.0.0.1'
 
 # Graphite port
 $PORT = 2003

--- a/graphital.d/memory.rb
+++ b/graphital.d/memory.rb
@@ -7,12 +7,12 @@ free = %x{'free'}.split("\n")
 
 descriptions  = free[0].split(/\s+/).collect(&:strip)
 mem           = free[1].split(/\s+/).collect(&:strip)
-swap          = free[3].split(/\s+/).collect(&:strip)
+#swap          = free[3].split(/\s+/).collect(&:strip)
 buffers       = free[2].split(/\s+/).collect(&:strip)
 
 descriptions.shift
 mem.shift
-swap.shift
+#swap.shift
 buffers.shift
 buffers.shift
 
@@ -22,7 +22,7 @@ mem = mem.zip(descriptions)
   descriptions.pop
 end
 
-swap = swap.zip(descriptions)
+#swap = swap.zip(descriptions)
 
 descriptions.shift
 
@@ -36,6 +36,6 @@ buffers.each do |metric,description|
   puts "cache.#{description} #{metric}"
 end
 
-swap.each do |metric,description|
-  puts "swap.#{description} #{metric}"
-end
+#swap.each do |metric,description|
+#  puts "swap.#{description} #{metric}"
+#end


### PR DESCRIPTION
Swap metric in graphital does funny things on CentOS 7 systems.  Commented out for now, but continuing to investigate.  May not want to commit that change. Not sure. 

Also updated graphital.conf to not point at the old VMG server. 127.0.0.1 seems safe enough. 